### PR TITLE
Fix Issue #10 for watir v6.15 compatibility

### DIFF
--- a/lib/watigiri/locators/element/locator.rb
+++ b/lib/watigiri/locators/element/locator.rb
@@ -144,7 +144,7 @@ module Watigiri
     end
 
     class TextArea
-      class Locator < Watir::Locators::TextArea::Locator
+      class Locator
         include LocatorHelpers
 
         def regex?


### PR DESCRIPTION
Fixes #10

Not sure if this is the correct fix, but considering the parent class `Watir::Locators::TextArea::Locator` was removed, I assuming that `Locators::TextArea::Locator` no longer needs to inherit it.